### PR TITLE
Fix boiler shutdown service call

### DIFF
--- a/excess_power_control.yaml
+++ b/excess_power_control.yaml
@@ -345,7 +345,7 @@ action:
             entity_id: !input water_heater_switch
             state: "on"
         sequence:
-          - service: switch.turn_on
+          - service: switch.turn_off
             target:
               entity_id: !input water_heater_switch
           - service: logbook.log


### PR DESCRIPTION
## Summary
- fix the service call used to turn off the boiler in `excess_power_control.yaml`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684be2accb74833181d471fdad905ce3